### PR TITLE
[BroomDialog.tsx] hotfix: enabled mod can be undefined

### DIFF
--- a/vortex/src/views/BroomDialog.tsx
+++ b/vortex/src/views/BroomDialog.tsx
@@ -332,7 +332,7 @@ function mapStateToProps(state: types.IState): IConnectedProps {
         messages: util.getSafe(state, ['session', 'broom', 'messages'], []),
         matchedFiles: util.getSafe(state, ['session', 'broom', 'matchedFiles'], []),
         stagingPath: selectors.installPathForGame(state, gameId),
-        enabledMods: Object.keys(profileMods).filter(m => profileMods[m].enabled).map(x => mods[x]),
+        enabledMods: Object.keys(profileMods).filter(m => profileMods[m].enabled).filter(m => mods[m] != undefined).map(x => mods[x]),
         deleteOption: util.getSafe(state, ['settings', 'interface', 'broomDeleteFiles'], false),
         unhideOption: util.getSafe(state, ['settings', 'interface', 'broomUnhide'], false),
     };


### PR DESCRIPTION
- It seems that enabled mod can be undefined in Vortex 1.12.6

- I bet that it is because some folks switched from VortexBeta back to VortexStable and somewhat borked theirs mods so called database (some json internal vortex thingy)
-----
- Tested [Find Files] button, works OK
- Tested [Hide Files] button, works OK
- Tested Settings -> [Unhide files] button, works OK
